### PR TITLE
feat: Add `prepare` option

### DIFF
--- a/src/main/java/pro/civitaspo/embulk/input/http_json/config/PluginTask.java
+++ b/src/main/java/pro/civitaspo/embulk/input/http_json/config/PluginTask.java
@@ -1,85 +1,19 @@
 package pro.civitaspo.embulk.input.http_json.config;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.embulk.base.restclient.RestClientInputTaskBase;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;
-import pro.civitaspo.embulk.input.http_json.config.validation.annotations.ValueOfEnum;
 
-public interface PluginTask extends RestClientInputTaskBase {
-    public enum URIScheme {
-        http,
-        https;
-
-        public static URIScheme of(String value) {
-            return URIScheme.valueOf(value.toLowerCase(Locale.ENGLISH));
-        }
-    }
-
-    @Config("scheme")
-    @ConfigDefault("\"https\"")
-    @ValueOfEnum(enumClass = URIScheme.class)
-    public String getScheme();
-
-    @Config("host")
-    @NotBlank
-    public String getHost();
-
-    @Config("port")
-    @ConfigDefault("null")
-    public Optional<@Min(0) @Max(65535) Integer> getPort();
-
-    @Config("path")
-    @ConfigDefault("null")
-    public Optional<@NotBlank String> getPath();
-
-    @Config("headers")
-    @ConfigDefault("[]")
-    public List<@Size(min = 1, max = 1) Map<@NotBlank String, @NotBlank String>> getHeaders();
-
-    public static enum RequestMethod {
-        CONNECT,
-        GET,
-        POST,
-        PUT,
-        DELETE,
-        PATCH,
-        HEAD,
-        OPTIONS,
-        TRACE;
-
-        public static RequestMethod of(String value) {
-            return RequestMethod.valueOf(value.toUpperCase(Locale.ENGLISH));
-        }
-    }
-
-    @Config("method")
-    @ConfigDefault("\"GET\"")
-    @ValueOfEnum(enumClass = RequestMethod.class, caseSensitive = false)
-    public String getMethod();
-
-    @Config("params")
-    @ConfigDefault("[]")
-    public List<@Size(min = 1, max = 1) Map<@NotBlank String, @NotNull Object>> getParams();
-
-    @Config("body")
-    @ConfigDefault("null")
-    public Optional<JsonNode> getBody();
-
-    @Config("success_condition")
-    @ConfigDefault("\".status_code_class == 200\"")
-    public @NotBlank String getSuccessCondition();
+public interface PluginTask extends RestClientInputTaskBase, RequestOption {
 
     @Config("transformer")
     @ConfigDefault("\"[.response_body]\"")
@@ -105,8 +39,8 @@ public interface PluginTask extends RestClientInputTaskBase {
                 getNextParams();
 
         @Config("next_body_transformer")
-        @ConfigDefault("\".request_body\"")
-        public String getNextBodyTransformer();
+        @ConfigDefault("null")
+        public Optional<String> getNextBodyTransformer();
 
         @Config("while")
         @ConfigDefault("\"false\"")
@@ -121,87 +55,21 @@ public interface PluginTask extends RestClientInputTaskBase {
     @ConfigDefault("{}")
     public PagerOption getPager();
 
-    public interface RetryOption extends Task {
-        @Config("condition")
-        @ConfigDefault("\"true\"")
-        public String getCondition();
-
-        @Config("max_retries")
-        @ConfigDefault("7")
-        public int getMaxRetries();
-
-        @Config("initial_interval_millis")
-        @ConfigDefault("1000")
-        public int getInitialIntervalMillis();
-
-        @Config("max_interval_millis")
-        @ConfigDefault("60000")
-        public int getMaxIntervalMillis();
-    }
-
-    @Config("retry")
-    @ConfigDefault("{}")
-    public RetryOption getRetry();
-
     @Config("show_request_body_on_error")
     @ConfigDefault("true")
     @NotNull
     public Boolean getShowRequestBodyOnError();
 
     public interface PrepareOption extends Task {
-        public interface RequestOption extends Task {
+        public interface NamedRequestOption extends RequestOption {
             @Config("name")
             @NotBlank
             public String getName();
-
-            @Config("scheme")
-            @ConfigDefault("null")
-            public Optional<@ValueOfEnum(enumClass = URIScheme.class) String> getScheme();
-
-            @Config("host")
-            public Optional<@NotBlank String> getHost();
-
-            @Config("port")
-            @ConfigDefault("null")
-            public Optional<@Min(0) @Max(65535) Integer> getPort();
-
-            @Config("path")
-            @ConfigDefault("null")
-            public Optional<@NotBlank String> getPath();
-
-            @Config("headers")
-            @ConfigDefault("null")
-            public Optional<List<@Size(min = 1, max = 1) Map<@NotBlank String, @NotBlank String>>>
-                    getHeaders();
-
-            @Config("method")
-            @ConfigDefault("null")
-            public Optional<
-                            @ValueOfEnum(enumClass = RequestMethod.class, caseSensitive = false)
-                            String>
-                    getMethod();
-
-            @Config("params")
-            @ConfigDefault("null")
-            public Optional<List<@Size(min = 1, max = 1) Map<@NotBlank String, @NotNull Object>>>
-                    getParams();
-
-            @Config("body")
-            @ConfigDefault("null")
-            public Optional<JsonNode> getBody();
-
-            @Config("success_condition")
-            @ConfigDefault("null")
-            public Optional<@NotBlank String> getSuccessCondition();
-
-            @Config("retry")
-            @ConfigDefault("null")
-            public Optional<RetryOption> getRetry();
         }
 
         @Config("requests")
         @ConfigDefault("[]")
-        public List<RequestOption> getRequests();
+        public List<NamedRequestOption> getRequests();
 
         public interface AssignToOption extends Task {
             @Config("params")
@@ -218,8 +86,8 @@ public interface PluginTask extends RestClientInputTaskBase {
     }
 
     @Config("prepare")
-    @ConfigDefault("{}")
-    public List<PrepareOption> getPrepare();
+    @ConfigDefault("null")
+    public Optional<PrepareOption> getPrepare();
 
     @Config("default_timezone")
     @ConfigDefault("\"UTC\"")

--- a/src/main/java/pro/civitaspo/embulk/input/http_json/config/PluginTask.java
+++ b/src/main/java/pro/civitaspo/embulk/input/http_json/config/PluginTask.java
@@ -71,18 +71,14 @@ public interface PluginTask extends RestClientInputTaskBase, RequestOption {
         @ConfigDefault("[]")
         public List<NamedRequestOption> getRequests();
 
-        public interface AssignToOption extends Task {
-            @Config("params")
-            @ConfigDefault("[]")
-            public List<Map<@NotBlank String, @NotNull String>> getParams();
+        @Config("prepared_params")
+        @ConfigDefault("[]")
+        public List<@Size(min = 1, max = 1) Map<@NotBlank String, @NotBlank Object>>
+                getPreparedParams();
 
-            @Config("body")
-            @ConfigDefault("null")
-            public Optional<String> getBody();
-        }
-
-        @Config("assign_to")
-        public AssignToOption getAssignTo();
+        @Config("prepared_body_transformer")
+        @ConfigDefault("null")
+        public Optional<String> getPreparedBodyTransformer();
     }
 
     @Config("prepare")

--- a/src/main/java/pro/civitaspo/embulk/input/http_json/config/RequestOption.java
+++ b/src/main/java/pro/civitaspo/embulk/input/http_json/config/RequestOption.java
@@ -1,0 +1,108 @@
+package pro.civitaspo.embulk.input.http_json.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.Task;
+import pro.civitaspo.embulk.input.http_json.config.validation.annotations.ValueOfEnum;
+
+public interface RequestOption extends Task {
+    public enum URIScheme {
+        http,
+        https;
+
+        public static URIScheme of(String value) {
+            return URIScheme.valueOf(value.toLowerCase(Locale.ENGLISH));
+        }
+    }
+
+    public static enum RequestMethod {
+        CONNECT,
+        GET,
+        POST,
+        PUT,
+        DELETE,
+        PATCH,
+        HEAD,
+        OPTIONS,
+        TRACE;
+
+        public static RequestMethod of(String value) {
+            return RequestMethod.valueOf(value.toUpperCase(Locale.ENGLISH));
+        }
+    }
+
+    public interface RetryOption extends Task {
+        @Config("condition")
+        @ConfigDefault("\"true\"")
+        public String getCondition();
+
+        @Config("max_retries")
+        @ConfigDefault("7")
+        public int getMaxRetries();
+
+        @Config("initial_interval_millis")
+        @ConfigDefault("1000")
+        public int getInitialIntervalMillis();
+
+        @Config("max_interval_millis")
+        @ConfigDefault("60000")
+        public int getMaxIntervalMillis();
+    }
+
+    @Config("scheme")
+    @ConfigDefault("\"https\"")
+    @ValueOfEnum(enumClass = URIScheme.class)
+    public String getScheme();
+
+    @Config("host")
+    @NotBlank
+    public String getHost();
+
+    @Config("port")
+    @ConfigDefault("null")
+    public Optional<@Min(0) @Max(65535) Integer> getPort();
+
+    @Config("path")
+    @ConfigDefault("null")
+    public Optional<@NotBlank String> getPath();
+
+    @Config("headers")
+    @ConfigDefault("[]")
+    public List<@Size(min = 1, max = 1) Map<@NotBlank String, @NotBlank String>> getHeaders();
+
+    @Config("method")
+    @ConfigDefault("\"GET\"")
+    @ValueOfEnum(enumClass = RequestMethod.class, caseSensitive = false)
+    public String getMethod();
+
+    @Config("params")
+    @ConfigDefault("[]")
+    public List<@Size(min = 1, max = 1) Map<@NotBlank String, @NotNull Object>> getParams();
+
+    @Config("body")
+    @ConfigDefault("null")
+    public Optional<JsonNode> getBody();
+
+    @Config("success_condition")
+    @ConfigDefault("\".status_code_class == 200\"")
+    public @NotBlank String getSuccessCondition();
+
+    @Config("retry")
+    @ConfigDefault("{}")
+    public RetryOption getRetry();
+
+    @Config("show_request_body_on_error")
+    @ConfigDefault("true")
+    @NotNull
+    public Boolean getShowRequestBodyOnError();
+}


### PR DESCRIPTION
- The `prepare` option has 3 options that are `requests`, `prepared_params` and `prepared_body_transformer`.
    - `requests`: The definitions to execute http request for the preparation.
    - `prepared_params`: Array of param key and jq filter map. The jq filter is used to create a value for the param key from the prepared requests/responces.
    - `prepared_body`: The jq filter to create the body from the prepared requests/responces.
- I will write the usage to README in the next PR.